### PR TITLE
Assign correct ip in output message

### DIFF
--- a/fast_ai/start_spot.sh
+++ b/fast_ai/start_spot.sh
@@ -22,11 +22,11 @@ echo Spot instance ID: $instance_id
 echo 'Please allow the root volume swap script a few minutes to finish.'
 if [ "x$ec2spotter_elastic_ip" = "x" ]
 then
-	# Elastic IP
-	export ip=`aws ec2 describe-addresses --allocation-ids $ec2spotter_elastic_ip --output text --query 'Addresses[0].PublicIp'`
-else
 	# Non elastic IP
 	export ip=`aws ec2 describe-instances --instance-ids $instance_id --filter Name=instance-state-name,Values=running --query "Reservations[*].Instances[*].PublicIpAddress" --output=text`
+else
+	# Elastic IP
+	export ip=`aws ec2 describe-addresses --allocation-ids $ec2spotter_elastic_ip --output text --query 'Addresses[0].PublicIp'`
 fi	
 
 export name=fast-ai


### PR DESCRIPTION
If the `$ec2spotter_elastic_ip` variable is not set, then the conditional will evaluate to true, and go into the first branch, which gets the elastic ip to display in the output message. But if the elastic ip is not set, it should display the other ip. I have swapped the branches, but equivalently, the conditional could be `!=` instead of `=`.